### PR TITLE
added links to public datasets in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,12 @@ Check out the example datasets in this repo.
 - [socialmediamanager-dataset.jsonl](socialmediamanager-dataset.jsonl)
 - please PR more!
 
+### Public Datasets (still need to be formatted)
+- [Open Subtitles](https://www.opensubtitles.com/en)
+- [Awesome Public Datasets](https://github.com/awesomedata/awesome-public-datasets)
+- [Kaggle Datasets](https://www.kaggle.com/datasets)
+- [Google Dataset Search](https://datasetsearch.research.google.com/)
+
 ## Getting Started
 
 - https://platform.openai.com/docs/guides/fine-tuning/fine-tuning-examples


### PR DESCRIPTION
Adding some links to public datasets to the readme. These still need to be worked on to get into JSONL format but can be a source for some domain-specific data.